### PR TITLE
Added 2 new command's for Nginx that mimic Apache2's a2ensite and a2dissite command

### DIFF
--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -55,6 +55,72 @@ EOF
 
 sudo ln -s /etc/nginx/sites-available/vagrant /etc/nginx/sites-enabled/vagrant
 
+echo ">>> Creating ngxen and ngxdis in /usr/local/bin/"
+# Lightly adjusted version of: https://blog.kamal.io/post/nginx-apache-like-server-structure/
+
+# Create ngxen
+cat > /usr/local/bin/ngxen << EOF
+#!/usr/bin/env bash
+
+if [[ $EUID -ne 0 ]]; then
+    echo "You must be root: \"sudo ngxen\""
+    exit 1
+fi
+
+# -z str: Returns True if the length of str is equal to zero.
+if [ -z "$1" ]; then
+    echo "Please choose a site."
+    exit 1
+else
+    echo "Enabling site $1..."
+    # -h filename: True if file exists and is a symbolic link.
+    # -f filename: Returns True if file, filename is an ordinary file.
+    if [ -h "/etc/nginx/sites-enabled/$1" || -f "/etc/nginx/sites-enabled/$1" ]; then
+        echo "$1 is already enabled."
+        exit 1
+    else
+        if [ ! -f "/etc/nginx/sites-available/$1" ]; then
+            echo "Site $1 does not exist in /etc/nginx/sites-available."
+            exit 1
+        else
+            ln -s /etc/nginx/sites-available/$1 /etc/nginx/sites-enabled/$1
+            echo "Enabled $1"
+            exit 0
+        fi
+    fi
+fi
+EOF
+
+# Create ngxdis
+cat > /usr/local/bin/ngxdis << EOF
+#!/usr/bin/env bash
+
+if [[ $EUID -ne 0 ]]; then
+    echo "You must be root: \"sudo ngxdis\""
+    exit 1
+fi
+
+# -z str: Returns True if the length of str is equal to zero.
+if [ -z "$1" ]; then
+    echo "Please choose a site."
+    exit 1
+else
+    echo "Disabling site $1..."
+    # -h filename: True if file exists and is a symbolic link.
+    # -f filename: Returns True if file, filename is an ordinary file.
+    if [ ! -h "/etc/nginx/sites-enabled/$1" || ! -f "/etc/nginx/sites-enabled/$1" ]; then
+        echo "$1 is not enabled."
+        exit 1
+    else
+        rm /etc/nginx/sites-enabled/$1
+        echo "Disabled $1"
+    fi
+fi
+EOF
+
+# Make sure that ngxen and ngxdis have execution permission
+sudo chmod 700 /usr/local/bin/ngxen /usr/local/bin/ngxdis
+
 # PHP Config for Nginx
 sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php5/fpm/php.ini
 sed -i "s/display_errors = .*/display_errors = On/" /etc/php5/fpm/php.ini


### PR DESCRIPTION
This add's 2 Nginx command's that act the same as the apache command: a2ensite and a2dissite. You can use them to enable or disable a vhost.

For instance you got a vhost in sites-availabe named "site-one". You can then do the fallowing to enable it: `sudo ngxen site-one` or if you want to disable it `sudo ngxdis site-one`. This basically just add's or delete's symlink's between site-available and site-enabled.

Credits and for more info see: https://blog.kamal.io/post/nginx-apache-like-server-structure/ .
