### PR TITLE
Add static asset caching to Nginx default config.

### DIFF
--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -49,6 +49,13 @@ server {
         fastcgi_param LARA_ENV local; # Environment variable for Laravel
         include fastcgi_params;
     }
+    
+    # Caching for static files
+    location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {
+        expires max;
+        add_header Pragma public;
+        add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+    }
 
     # Deny .htaccess file access
     location ~ /\.ht {


### PR DESCRIPTION
Tried the old config with laravel and static assets were being interpreted as routes and were breaking. This should fix that.
