### PR TITLE
Added the option to install PHPUnit

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -114,5 +114,8 @@ Vagrant.configure("2") do |config|
 
   # Install Yeoman
   # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/yeoman.sh", privileged: false
+  
+  # Install PHPUnit
+  # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/phpunit.sh"
 
 end

--- a/readme.md
+++ b/readme.md
@@ -222,6 +222,9 @@ This will also attempt to change the Apache or Nginx virtual host to point the d
 
 This will install Yeoman globally for you to use in your front-end projects.
 
+### PHPUnit
+
+This will install PHPUnit and make it globally accessible.
 
 ## The Vagrantfile
 

--- a/scripts/phpunit.sh
+++ b/scripts/phpunit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+echo ">>> Installing PHPUnit"
+
+# PHPUnit
+wget https://phar.phpunit.de/phpunit.phar
+chmod +x phpunit.phar
+mv phpunit.phar /usr/local/bin/phpunit


### PR DESCRIPTION
This PR adds the option to install PHPUnit globally in the Vagrant machine. It places the `phpunit.phar` file into `/usr/local/bin/`. The phar file includes all of the necessary dependencies required by PHPUnit. This is more convienient than installing PHPUnit through composer as it's immediately available globally without having to modify the $PATH. 
