### PR TITLE
Turn off cgi.fix_pathinfo when using Nginx

### DIFF
--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -70,6 +70,7 @@ sudo ngxen vagrant
 # PHP Config for Nginx
 sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php5/fpm/php.ini
 sed -i "s/display_errors = .*/display_errors = On/" /etc/php5/fpm/php.ini
+sed -i "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/" /etc/php5/fpm/php.ini
 
 sudo service php5-fpm restart
 sudo service nginx restart


### PR DESCRIPTION
It's been recommended in a few article's about setting up Nginx (just google "cgi.fix_pathinfo" for more info). It's default is set to 1 even if it's commented out. It's got to do with security.
