### PR TITLE
Added the option to install CouchDB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,6 +78,9 @@ Vagrant.configure("2") do |config|
 
   # Provision SQLite
   # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/sqlite.sh"
+  
+  # Provision CouchDB
+  # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/couchdb.sh"
 
 
   ####

--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,19 @@ This will install the SQLite server.
 
 SQLite runs either in-memory (good for unit testing) or file-based.
 
+### CouchDB
+
+This will install the CouchDB database.
+
+To create a new databse:
+
+```bash
+# Execute this command inside the Vagrant box
+$ curl -X PUT localhost:5984/name_of_new_database
+```
+
+You may access the "Futon" web interface for administering CouchDB at: `http://192.168.33.10:5984/_utils/`
+
 
 ### In-Memory Stores
 ---

--- a/scripts/couchdb.sh
+++ b/scripts/couchdb.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo ">>> Installing CouchDB"
+
+# Install CouchDB
+sudo apt-get install couchdb -y
+
+# Make Futon Available
+sudo sed -i 's/;bind_address = 127.0.0.1/bind_address = 0.0.0.0/' /etc/couchdb/local.ini


### PR DESCRIPTION
This PR adds the option to install CouchDB. Also it makes the Futon web interface of Couch available at http://192.168.33.10:5984/_utils/. With its acceptance I'll submit a PR to update the gh-pages repo.
