### PR TITLE
Added rvm.sh (Ruby Version Manager)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,9 +8,10 @@ github_branch   = "master"
 
 # Some variables
 server_ip             = "192.168.33.10"
-mysql_root_password   = "root" # We'll assume user "root"
-mysql_version         = "5.5"  # Options: 5.5 | 5.6
-pgsql_root_password   = "root" # We'll assume user "root"
+mysql_root_password   = "root"   # We'll assume user "root"
+mysql_version         = "5.5"    # Options: 5.5 | 5.6
+pgsql_root_password   = "root"   # We'll assume user "root"
+ruby_version          = "latest" # Choose what ruby version should be installed (will also be the default version)
 
 Vagrant.configure("2") do |config|
 
@@ -114,6 +115,9 @@ Vagrant.configure("2") do |config|
   # Install Nodejs
   # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/nodejs.sh", privileged: false
 
+
+  # Install Ruby Version Manager (RVM)
+  # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/rvm.sh", privileged: false, args: ruby_version
 
   ####
   # Frameworks, etc

--- a/scripts/rvm.sh
+++ b/scripts/rvm.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Check if RVM is installed
+RVM -v > /dev/null 2>&1
+RVM_IS_INSTALLED=$?
+
+if [[ $RVM_IS_INSTALLED -eq 0 ]]; then
+    echo ">>> Updating Ruby Version Manager"
+    rvm get stable --ignore-dotfiles
+else
+    # Install RVM and install Ruby
+    if [[ -z $1 || $1 -eq "latest" ]]; then
+        echo ">>> Installing Ruby Version Manager and installing latest stable Ruby version"
+
+        # Install RVM and install latest stable Ruby version
+        \curl -sSL https://get.rvm.io | bash -s stable --ruby
+    else
+        echo ">>> Installing Ruby Version Manager and installing Ruby version: $1"
+
+        # Install RVM and install selected Ruby version
+        \curl -sSL https://get.rvm.io | bash -s stable --ruby=$1
+    fi
+
+    # Reload .bash_profile and/or .zshrc if they exist
+    if [[ -f "home/vagrant/.bash_profile" ]]; then
+        . ~/.bash_profile
+    fi
+
+    if [[ -f "home/vagrant/.zshrc" ]]; then
+        . ~/.zshrc
+    fi
+fi


### PR DESCRIPTION
This will install Ruby Version Manager (RVM). There is a variable called "ruby_version" where you can change the default ruby that should be installed by RVM.

I called the script "rvm.sh", but it could also be "ruby.sh" instead? Not sure what is preferred? If it's ruby.sh, then just let me know and I can change that quickly.
