### PR TITLE
Adjust PHP provisioning to allow older versions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,15 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/base.sh"
 
   # Provision PHP
-  config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/php.sh"
+
+    # Update to latest repo (5.5)
+    config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/php-latest.sh"
+
+    # Update to previous stable repo (5.4)
+    # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/php-54.sh"
+
+    # Install PHP with specified repo
+    config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/php.sh"
 
   # Provision Oh-My-Zsh
   # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/zsh.sh"
@@ -80,7 +88,7 @@ Vagrant.configure("2") do |config|
 
   # Provision SQLite
   # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/sqlite.sh"
-  
+
   # Provision CouchDB
   # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/couchdb.sh"
 

--- a/scripts/php-54.sh
+++ b/scripts/php-54.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Add repo for latest PHP
+sudo add-apt-repository -y ppa:ondrej/php5-oldstable
+
+# Update Again
+sudo apt-get update

--- a/scripts/php-latest.sh
+++ b/scripts/php-latest.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Add repo for latest PHP
+sudo add-apt-repository -y ppa:ondrej/php5
+
+# Update Again
+sudo apt-get update

--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-# Add repo for latest PHP
-sudo add-apt-repository -y ppa:ondrej/php5
-
-# Update Again
-sudo apt-get update
-
 # Install PHP
 sudo apt-get install -y php5-cli php5-mysql php5-pgsql php5-sqlite php5-curl php5-gd php5-gmp php5-mcrypt php5-xdebug php5-memcached
 


### PR DESCRIPTION
I have to work on a couple of dozen PHP-based projects and they tend to run over several versions.

One of the huge benefits of Vagrant is not having to worry about this when doing local development.

This request includes changes to allow you to run with:
- Latest and greatest (PHP 5.5 right now)
- Previous stable (PHP 5.4 right now)
- The distributed version (PHP 5.3 with 12.04)

It changes the main php.sh to just install and prior to that you can optionally include one of the more up-to-date repositories
