### PR TITLE
PHP5-FPM Support For Apache

### DIFF
--- a/scripts/apache.sh
+++ b/scripts/apache.sh
@@ -4,13 +4,20 @@ echo ">>> Installing Apache Server"
 
 [[ -z "$1" ]] && { echo "!!! IP address not set. Check the Vagrant file."; exit 1; }
 
+# Add repo for latest FULL stable Apache
+# (Required to remove conflicts with PHP PPA due to partial Apache upgrade within it)
+sudo add-apt-repository -y ppa:ondrej/apache2
+
+# Update Again
+sudo apt-get update
+
 # Install Apache
-sudo apt-get install -y apache2 php5 libapache2-mod-php5
+sudo apt-get install -y apache2-mpm-event libapache2-mod-fastcgi
 
 echo ">>> Configuring Apache"
 
 # Apache Config
-sudo a2enmod rewrite
+sudo a2enmod rewrite actions
 curl https://gist.github.com/fideloper/2710970/raw/vhost.sh > vhost
 sudo chmod guo+x vhost
 sudo mv vhost /usr/local/bin
@@ -19,7 +26,19 @@ sudo mv vhost /usr/local/bin
 sudo vhost -s $1.xip.io -d /vagrant
 
 # PHP Config for Apache
-sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php5/apache2/php.ini
-sed -i "s/display_errors = .*/display_errors = On/" /etc/php5/apache2/php.ini
+cat > /etc/apache2/conf-available/php5-fpm.conf << EOF
+<IfModule mod_fastcgi.c>
+        AddHandler php5-fcgi .php
+        Action php5-fcgi /php5-fcgi
+        Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+        FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -socket /var/run/php5-fpm.sock -pass-header Authorization
+        <Directory /usr/lib/cgi-bin>
+                Options ExecCGI FollowSymLinks
+                SetHandler fastcgi-script
+                Require all granted
+        </Directory>
+</IfModule>
+EOF
+sudo a2enconf php5-fpm
 
 sudo service apache2 restart

--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -11,7 +11,7 @@ sudo add-apt-repository -y ppa:nginx/stable
 sudo apt-get update
 
 # Install the Rest
-sudo apt-get install -y nginx php5-fpm
+sudo apt-get install -y nginx
 
 echo ">>> Configuring Nginx"
 
@@ -73,8 +73,6 @@ sudo ngxdis default
 sudo ngxen vagrant
 
 # PHP Config for Nginx
-sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php5/fpm/php.ini
-sed -i "s/display_errors = .*/display_errors = On/" /etc/php5/fpm/php.ini
 sed -i "s/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/" /etc/php5/fpm/php.ini
 
 sudo service php5-fpm restart

--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -21,7 +21,7 @@ fi
 sudo apt-get update
 
 # Install PHP
-sudo apt-get install -y php5-cli php5-mysql php5-pgsql php5-sqlite php5-curl php5-gd php5-gmp php5-mcrypt php5-xdebug php5-memcached php5-imagick
+sudo apt-get install -y php5-cli php5-fpm php5-mysql php5-pgsql php5-sqlite php5-curl php5-gd php5-gmp php5-mcrypt php5-xdebug php5-memcached php5-imagick
 
 # xdebug Config
 cat > /etc/php5/mods-available/xdebug.ini << EOF
@@ -29,3 +29,14 @@ xdebug.scream=1
 xdebug.cli_color=1
 xdebug.show_local_vars=1
 EOF
+
+# PHP Error Reporting Config
+sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php5/fpm/php.ini
+sed -i "s/display_errors = .*/display_errors = On/" /etc/php5/fpm/php.ini
+
+# Make sure php5-fpm is running as a Unix socket on "distributed" version
+if [ $php_version == "distributed" ]; then
+    sed -i "s/listen = .*/listen = \/var\/run\/php5-fpm.sock/" /etc/php5/fpm/pool.d/www.conf
+fi
+
+sudo service php5-fpm restart


### PR DESCRIPTION
Add support for php5-fpm for Apache by replacing mod-php5 with mod-fastcgi and make php5-fpm as the default PHP install.
