### PR TITLE
Adding mail catcher install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -166,4 +166,7 @@ Vagrant.configure("2") do |config|
   # Install Supervisord
   # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/supervisord.sh"
 
+  # Install Mailcatcher (configures php.ini to use catchmail)
+  # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/mailcatcher.sh"
+
 end

--- a/readme.md
+++ b/readme.md
@@ -288,6 +288,10 @@ This will install PHPUnit and make it globally accessible.
 
 This will install Screen on the Vagrant machine.
 
+### MailCatcher
+
+This will install mailcatcher and set the php.ini path to catchmail.
+
 ## The Vagrantfile
 
 The vagrant file does two things you should take note of:

--- a/scripts/mailcatcher.sh
+++ b/scripts/mailcatcher.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+echo ">>> Installing Mailcatcher"
+
+#dependancy
+sudo apt-get install -y libsqlite3-dev
+
+
+if $(which rvm) -v > /dev/null 2>&1; then
+	echo ">>>>Installing with RVM"
+	$(which rvm) default@mailcatcher --create do gem install --no-rdoc --no-ri mailcatcher
+	$(which rvm) wrapper default@mailcatcher --no-prefix mailcatcher catchmail
+else
+	#gem check
+	if ! gem -v > /dev/null 2>&1; then sudo aptitude install -y libgemplugin-ruby; fi
+
+	#install
+	gem install --no-rdoc --no-ri mailcatcher
+fi
+
+
+#make it start on boot
+sudo echo "@reboot $(which mailcatcher) --ip=0.0.0.0" >> /etc/crontab
+sudo update-rc.d cron defaults
+
+#make php use it to send mail
+sudo echo "sendmail_path = /usr/bin/env $(which catchmail)" >> /etc/php5/cli/php.ini
+
+#start it now
+/usr/bin/env $(which mailcatcher) --ip=0.0.0.0
+
+#add aliases
+if [[ -f "/home/vagrant/.bash_profile" ]]; then
+	sudo echo "alias mailcatcher=\"mailcatcher --ip=0.0.0.0\"" >> /home/vagrant/.bash_profile
+	. /home/vagrant/.bash_profile
+fi
+
+if [[ -f "/home/vagrant/.zshrc" ]]; then
+	sudo echo "alias mailcatcher=\"mailcatcher --ip=0.0.0.0\"" >> /home/vagrant/.zshrc
+	. /home/vagrant/.zshrc
+fi
+
+if [[ -f "/home/vagrant/.bashrc" ]]; then
+	sudo echo "alias mailcatcher=\"mailcatcher --ip=0.0.0.0\"" >> /home/vagrant/.bashrc
+	. /home/vagrant/.bashrc
+fi


### PR DESCRIPTION
Installs mailcatcher, sets php.ini sendmail path to catchmail, and adds aliases to start mail catcher, and attempts to add cron job to have it start on boot. 

http://192.168.33.10.xip.io:1080 for mailcatcher frontend
192.168.33.10:1025 smtp port. 
