### PR TITLE
Added MariaDB - a MySQL replacement

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,8 @@ server_ip             = "192.168.33.10"
 mysql_root_password   = "root"   # We'll assume user "root"
 mysql_version         = "5.5"    # Options: 5.5 | 5.6
 pgsql_root_password   = "root"   # We'll assume user "root"
+mariadb_version       = "10.0"   # Options: 5.5 | 10.0
+mariadb_root_password = "root"   # We'll assume user "root"
 ruby_version          = "latest" # Choose what ruby version should be installed (will also be the default version)
 ruby_gems             = [        # List any Ruby Gems that you want to install
   #"jekyll",
@@ -106,6 +108,8 @@ Vagrant.configure("2") do |config|
   # Provision MongoDB
   # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/mongodb.sh"
 
+  # Provision MariaDB
+  # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/mariadb.sh", args: [mariadb_root_password, mariadb_version]
 
   ####
   # Search Servers

--- a/scripts/mariadb.sh
+++ b/scripts/mariadb.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+echo ">>> Installing MariaDB"
+
+[[ -z $1 ]] && { echo "!!! MariaDB root password not set. Check the Vagrant file."; exit 1; }
+
+# default version
+MARIADB_VERSION='10.0'
+
+if [[ ! -z $2 && $2 == '5.5' ]]; then
+    MARIADB_VERSION='5.5'
+fi
+
+# Import repo key
+sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
+
+# Add repo for MariaDB
+sudo add-apt-repository -y "deb http://mirrors.supportex.net/mariadb/repo/$MARIADB_VERSION/ubuntu precise main"
+
+# Update
+sudo apt-get update
+
+# Install MariaDB without password prompt
+# Set username to 'root' and password to 'mariadb_root_password' (see Vagrantfile)
+sudo debconf-set-selections <<< "maria-db-$MARIADB_VERSION mysql-server/root_password password $1"
+sudo debconf-set-selections <<< "maria-db-$MARIADB_VERSION mysql-server/root_password_again password $1"
+
+# Install MariaDB
+sudo apt-get install -y mariadb-server


### PR DESCRIPTION
MariaDB 10.0 will be installed by default. You can also choose to install MariaDB 5.5. Just like with the MySQL script, you can change the password within Vagrantfile (User is 'root').

Both versions seem to work (tested it by connecting to it with Sequel Pro and creating a database and a table).
