### PR TITLE
Added -L option to cURL to follow redirects.

### DIFF
--- a/scripts/apache.sh
+++ b/scripts/apache.sh
@@ -18,7 +18,7 @@ echo ">>> Configuring Apache"
 
 # Apache Config
 sudo a2enmod rewrite actions ssl
-curl https://gist.github.com/fideloper/2710970/raw/vhost.sh > vhost
+curl -L https://gist.github.com/fideloper/2710970/raw/vhost.sh > vhost
 sudo chmod guo+x vhost
 sudo mv vhost /usr/local/bin
 


### PR DESCRIPTION
I was trying to provision Vagrant with Apache and the virtual host wasn't being created. 

I fired up https://gist.github.com/fideloper/2710970/raw/vhost.sh in the browser and was being redirected to https://gist.githubusercontent.com/fideloper/2710970/raw/vhost.sh instead.
