### PR TITLE
added support for php xdebug, added phpspec and gulp to vangrant default

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,12 +29,14 @@ php_version           = "latest" # Options: latest|previous|distributed   For 12
 composer_packages     = [        # List any global Composer packages that you want to install
   #"phpunit/phpunit:3.7.*",
   #"codeception/codeception=*",
+  #"phpspec/phpspec:2.0.*@dev",
 ]
 laravel_root_folder   = "/vagrant/laravel" # Where to install Laravel. Will `composer install` if a composer.json file exists
 symfony_root_folder   = "/vagrant/symfony" # Where to install Symfony.
 nodejs_version        = "latest"   # By default "latest" will equal the latest stable version
 nodejs_packages       = [          # List any global NodeJS packages that you want to install
   #"grunt-cli",
+  #"gulp",
   #"bower",
   #"yo",
 ]

--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -24,6 +24,11 @@ sudo apt-get install -y php5-cli php5-fpm php5-mysql php5-pgsql php5-sqlite php5
 
 # xdebug Config
 cat >> /etc/php5/mods-available/xdebug.ini << EOF
+xdebug.kdekey = "PHPStorm"
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 1
+xdebug.remote_connect_back = 1
+xdebug.remote_port = 9000
 xdebug.scream=1
 xdebug.cli_color=1
 xdebug.show_local_vars=1


### PR DESCRIPTION
Added the following to Vagrant file:
- added phpspec in list of packages available to composer (along phpunit and codeception)
- added gulp in list of packages available to nodejs (along with grunt)
- added xDebug/PHPStorm settings when creating web server
