### PR TITLE
Bug fixed 'No such file or directory' with xdebug

### DIFF
--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -24,7 +24,7 @@ sudo apt-get install -y php5-cli php5-fpm php5-mysql php5-pgsql php5-sqlite php5
 
 # xdebug Config
 cat > $(find /etc/php5 -name xdebug.ini) << EOF
-$(cat $(find / -name xdebug.ini-dist))
+zend_extension=$(find /usr/lib/php5 -name xdebug.so)
 xdebug.kdekey = "PHPStorm"
 xdebug.remote_enable = 1
 xdebug.remote_autostart = 1


### PR DESCRIPTION
Hi,

I don't know if it's really a bug, but in my case is one.

With the "previous" version of php (5.3) and with "php5-xdebug" installation, no directory "mods-available" was created, and so the "/etc/php5/mods-available/xedbug.ini" file didn't exist.

I don't know if my correction is clean, but it's working in my case.

I've also set the "html_errors" to "On" for the 'var_dump' display.
