### PR TITLE
Resource RVM

### DIFF
--- a/scripts/rvm.sh
+++ b/scripts/rvm.sh
@@ -28,7 +28,7 @@ if [[ $RVM_IS_INSTALLED -eq 0 ]]; then
     rvm get stable --ignore-dotfiles
 else
     # Install RVM and install Ruby
-    if [[ $RUBY_VERSION =~ "latest" ]]; then # experimental =~. This should pass "latest", " latest" and "latest "
+    if [[ $RUBY_VERSION =~ "latest" ]]; then
         echo ">>> Installing Ruby Version Manager and installing latest stable Ruby version"
 
         # Install RVM and install latest stable Ruby version
@@ -40,7 +40,10 @@ else
         \curl -sSL https://get.rvm.io | bash -s stable --ruby=$RUBY_VERSION
     fi
 
-    # Re-source .profile, .zshrc or .bashrc if they exist
+    # Re-source RVM
+    . /home/vagrant/.rvm/scripts/rvm
+
+    # Re-source .profile or .zshrc if they exist
     if [[ -f "/home/vagrant/.profile" ]]; then
         . /home/vagrant/.profile
     fi


### PR DESCRIPTION
Resourcing RVM seemed to fix the permission issue's. I tried installing the fallowing gems:

``` ruby
...
ruby_gems             = [        # List any Ruby Gems that you want to install
  "jekyll",
  "bundler",
  "guard"
]
...
```

Both `Jekyll` and `Bundler` installed fine, but `Guard` threw an error:

```
RROR:  Error installing guard:
    ERROR: Failed to build gem native extension.

    /home/vagrant/.rvm/rubies/ruby-2.1.0/bin/ruby extconf.rb
Cannot allocate memory - /home/vagrant/.rvm/rubies/ruby-2.1.0/bin/ruby extconf.rb 2>&1

Gem files will remain installed in /home/vagrant/.rvm/gems/ruby-2.1.0/gems/nio4r-1.0.0 for inspection.
Results logged to /home/vagrant/.rvm/gems/ruby-2.1.0/extensions/x86_64-linux/2.1.0/nio4r-1.0.0/gem_make.out
```

I could however just install it manually without any hiccups after logging in (`vagrant ssh`).
#185
