### PR TITLE
git setup

### DIFF
--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -33,3 +33,9 @@ sudo mkdir -p "$SSL_DIR"
 sudo openssl genrsa -out "$SSL_DIR/xip.io.key" 1024
 sudo openssl req -new -subj "$(echo -n "$SUBJ" | tr "\n" "/")" -key "$SSL_DIR/xip.io.key" -out "$SSL_DIR/xip.io.csr" -passin pass:$PASSPHRASE
 sudo openssl x509 -req -days 365 -in "$SSL_DIR/xip.io.csr" -signkey "$SSL_DIR/xip.io.key" -out "$SSL_DIR/xip.io.crt"
+
+# Common fixes for git
+git config --global http.postBuffer 524288000
+
+# Cache http credentials for one day while pull/push
+git config --global credential.helper 'cache --timeout=86400'


### PR DESCRIPTION
fixes error like: error: RPC failed; result=22, HTTP code = 411

``` php
git config --global http.postBuffer 524288000
```

saves password for one day, probably for vagrant boxes it is ok?

``` php
git config --global credential.helper 'cache --timeout=86400'
```
