### PR TITLE
Resolving nginx's no input file specified error

### DIFF
--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -46,6 +46,7 @@ server {
     # Note: \.php$ is susceptible to file upload attacks
     # Consider using: "location ~ ^/(index|app|app_dev|config)\.php(/|$) {"
     location ~ \.php$ {
+        try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         # With php5-fpm:
         fastcgi_pass unix:/var/run/php5-fpm.sock;
@@ -93,6 +94,7 @@ server {
     # Note: \.php$ is susceptible to file upload attacks
     # Consider using: "location ~ ^/(index|app|app_dev|config)\.php(/|$) {"
     location ~ \.php$ {
+        try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         # With php5-fpm:
         fastcgi_pass unix:/var/run/php5-fpm.sock;


### PR DESCRIPTION
Added try_files to the PHP fastCGI to catch non-existent URLs and display an 404 error page instead
See: http://nginxlibrary.com/resolving-no-input-file-specified-error/
