### PR TITLE
Missing newline when appending to .profile/.zshrc

### DIFF
--- a/scripts/mailcatcher.sh
+++ b/scripts/mailcatcher.sh
@@ -34,11 +34,11 @@ sudo service apache2 restart
 
 #add aliases
 if [[ -f "/home/vagrant/.profile" ]]; then
-	sudo echo "alias mailcatcher=\"mailcatcher --ip=0.0.0.0\"" >> /home/vagrant/.profile
+	sudo echo "\nalias mailcatcher=\"mailcatcher --ip=0.0.0.0\"" >> /home/vagrant/.profile
 	. /home/vagrant/.profile
 fi
 
 if [[ -f "/home/vagrant/.zshrc" ]]; then
-	sudo echo "alias mailcatcher=\"mailcatcher --ip=0.0.0.0\"" >> /home/vagrant/.zshrc
+	sudo echo "\nalias mailcatcher=\"mailcatcher --ip=0.0.0.0\"" >> /home/vagrant/.zshrc
 	. /home/vagrant/.zshrc
 fi


### PR DESCRIPTION
Currently, there is a missing newline before the string when writing this alias which ends up creating:

export NODE_PATH=$NODE_PATH:~/npm/lib/node_modulesalias mailcatcher="mailcatcher --ip=0.0.0.0"
