### PR TITLE
Install HVVM after nginx or Apache

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -125,12 +125,12 @@ Vagrant.configure("2") do |config|
   # Provision Apache Base
   # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/apache.sh", args: [server_ip, public_folder]
 
-  # Provision HHVM
-  # Install HHVM & HHVM-FastCGI
-  # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/hhvm.sh"
-
   # Provision Nginx Base
   # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/nginx.sh", args: [server_ip, public_folder]
+
+  # Provision HHVM & HHVM-FastCGI
+  # Note: Should be installed after either Apache or Nginx, incase one of these are installed.
+  # config.vm.provision "shell", path: "https://raw.github.com/#{github_username}/#{github_repo}/#{github_branch}/scripts/hhvm.sh"
 
 
   ####


### PR DESCRIPTION
Last time I tried HVVM it wasn't working, but incase it does it should be installed after nginx and apache (definitely now with the new 3.*.* release). HVVM will adjust some settings when either apache or nginx are installed.
