### PR TITLE
use laravel root folder to determine default public path

### DIFF
--- a/scripts/laravel.sh
+++ b/scripts/laravel.sh
@@ -22,7 +22,7 @@ else
 fi
 
 if [ -z "$3" ]; then
-    laravel_public_folder="/vagrant/laravel/public"
+    laravel_public_folder="$laravel_root_folder/public"
 else
     laravel_public_folder="$3"
 fi


### PR DESCRIPTION
Using the laravel root folder to determine the default public directory provides a more sensible default I think.
