### PR TITLE
use laravel root folder to guess the default public directory

### DIFF
--- a/scripts/laravel.sh
+++ b/scripts/laravel.sh
@@ -22,7 +22,7 @@ else
 fi
 
 if [ -z "$3" ]; then
-    laravel_public_folder="/vagrant/laravel/public"
+    laravel_public_folder="$laravel_root_folder/public"
 else
     laravel_public_folder="$3"
 fi


### PR DESCRIPTION
If a public directory isn't provided, use the `laravel_root_folder` to guess the public folder.
