### PR TITLE
Updated the xdebug.scream

### DIFF
--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -27,7 +27,7 @@ zend_extension=$(find /usr/lib/php5 -name xdebug.so)
 xdebug.remote_enable = 1
 xdebug.remote_connect_back = 1
 xdebug.remote_port = 9000
-xdebug.scream=1
+xdebug.scream=0
 xdebug.cli_color=1
 xdebug.show_local_vars=1
 


### PR DESCRIPTION
Ive been getting a PHPParser class issue recently and setting the xdebug.scream=1 to 0 seemed to have worked, for me. view issue post here http://laravel.io/forum/04-17-2014-undefined-variable-undefinedvariable-in-composer-install?page=1#reply-5314  and https://github.com/nikic/PHP-Parser/issues/89

This is only probably applicable if installing laravel and/or PHP-Parser. So not sure if the change is worth it as your files are for more than laravel.
