### PR TITLE
Set xdebug.scream to 0 to prevent issues with Laravel and PHP-Parser

### DIFF
--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -27,7 +27,7 @@ zend_extension=$(find /usr/lib/php5 -name xdebug.so)
 xdebug.remote_enable = 1
 xdebug.remote_connect_back = 1
 xdebug.remote_port = 9000
-xdebug.scream=1
+xdebug.scream=0
 xdebug.cli_color=1
 xdebug.show_local_vars=1
 


### PR DESCRIPTION
See https://github.com/nikic/PHP-Parser/issues/89 for the long issue about this.
