### PR TITLE
Increasing Nginx Client body size [wip]

### DIFF
--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -137,7 +137,7 @@ EOF
 # Turn off sendfile to be more compatible with Windows, which can't use NFS
 sed -i 's/sendfile on;/sendfile off;/' /etc/nginx/nginx.conf
 
-# set client body size to 5M #
+# set client body size to 5M 
 echo 'client_max_body_size 5M;' >> /etc/nginx/nginx.conf
 
 # Nginx enabling and disabling virtual hosts


### PR DESCRIPTION
Increasing of body sizes to 5MB instead of the default 1MB. Because I'm getting a lot of `413 Request Entity Too Large` responses. 1MB is not that much nowadays.
