### PR TITLE
Added --force-yes to php apt-get install for a temp fix

### DIFF
--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -7,7 +7,7 @@ sudo add-apt-repository -y ppa:ondrej/php5
 sudo apt-get update
 
 # Install PHP
-sudo apt-get install -y php5-cli php5-fpm php5-mysql php5-pgsql php5-sqlite php5-curl php5-gd php5-gmp php5-mcrypt php5-xdebug php5-memcached php5-imagick php5-intl
+sudo apt-get install --force-yes -y php5-cli php5-fpm php5-mysql php5-pgsql php5-sqlite php5-curl php5-gd php5-gmp php5-mcrypt php5-xdebug php5-memcached php5-imagick php5-intl
 
 # Set PHP FPM to listen on TCP instead of Socket
 sudo sed -i "s/listen =.*/listen = 127.0.0.1:9000/" /etc/php5/fpm/pool.d/www.conf


### PR DESCRIPTION
A temp fix for installing php by adding `--force-yes` to `apt-get install`. See #283
