### PR TITLE
Enable HHVM for composer and the Laravel installation

### DIFF
--- a/scripts/composer.sh
+++ b/scripts/composer.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 
 # Test if PHP is installed
-php -v > /dev/null 2>&1 || { printf "!!! PHP is not installed.\n    Installing Composer aborted!\n"; exit 0; }
+php -v > /dev/null 2>&1
+PHP_IS_INSTALLED=$?
+
+# Test if HHVM is installed
+hhvm --version > /dev/null 2>&1
+HHVM_IS_INSTALLED=$?
+
+[[ $HHVM_IS_INSTALLED -ne 0 && $PHP_IS_INSTALLED -ne 0 ]] && { printf "!!! PHP/HHVM is not installed.\n    Installing Composer aborted!\n"; exit 0; }
 
 # Test if Composer is installed
 composer -v > /dev/null 2>&1
@@ -13,15 +20,35 @@ COMPOSER_PACKAGES=($@)
 # True, if composer is not installed
 if [[ $COMPOSER_IS_INSTALLED -ne 0 ]]; then
     echo ">>> Installing Composer"
+    if [[ $HHVM_IS_INSTALLED -eq 0 ]]; then
+        # Install Composer
+        sudo wget https://getcomposer.org/installer
+        hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 installer
+        sudo mv composer.phar /usr/local/bin/composer
+        sudo rm installer
 
-    # Install Composer
-    curl -sS https://getcomposer.org/installer | php
-    sudo mv composer.phar /usr/local/bin/composer
+        # Add an alias that will allow us to use composer without timeout's
+        printf "\n# Add an alias for sudo\n%s\n# Use HHVM when using Composer\n%s" \
+        "alias sudo=\"sudo \"" \
+        "alias composer=\"hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 -v Eval.Jit=false /usr/local/bin/composer\"" \
+        >> "/home/vagrant/.profile"
+
+        # Resource .profile
+        # Doesn't seem to work do! The alias is only usefull from the moment you log in: vagrant ssh
+        . /home/vagrant/.profile
+    else
+        # Install Composer
+        curl -sS https://getcomposer.org/installer | php
+        sudo mv composer.phar /usr/local/bin/composer
+    fi
 else
     echo ">>> Updating Composer"
 
-    # Update Composer
-    sudo composer self-update
+    if [[ $HHVM_IS_INSTALLED -eq 0 ]]; then
+        sudo hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 -v Eval.Jit=false /usr/local/bin/composer self-update
+    else
+        sudo composer self-update
+    fi
 fi
 
 
@@ -30,17 +57,22 @@ if [[ ! -z $COMPOSER_PACKAGES ]]; then
 
     echo ">>> Installing Global Composer Packages:"
     echo "    " $@
-    composer global require $@
+    if [[ $HHVM_IS_INSTALLED -eq 0 ]]; then
+        hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 -v Eval.Jit=false /usr/local/bin/composer global require $@
+    else
+        composer global require $@
+    fi
 
     # Add Composer's Global Bin to ~/.profile path
     if [[ -f "/home/vagrant/.profile" ]]; then
-        # Ensure COMPOSER_HOME variable is set. This isn't set by Composer automatically
-        printf "\nCOMPOSER_HOME=\"/home/vagrant/.composer\"" >> /home/vagrant/.profile
-        # Add composer home vendor bin dir to PATH to run globally installed executables
-        printf "\n# Add Composer Global Bin to PATH\n%s" 'export PATH=$PATH:$COMPOSER_HOME/vendor/bin' >> /home/vagrant/.profile
+        if ! grep -qsc 'COMPOSER_HOME=' /home/vagrant/.profile; then
+            # Ensure COMPOSER_HOME variable is set. This isn't set by Composer automatically
+            printf "\n\nCOMPOSER_HOME=\"/home/vagrant/.composer\"" >> /home/vagrant/.profile
+            # Add composer home vendor bin dir to PATH to run globally installed executables
+            printf "\n# Add Composer Global Bin to PATH\n%s" 'export PATH=$PATH:$COMPOSER_HOME/vendor/bin' >> /home/vagrant/.profile
 
-        # Source the .profile to pick up changes
-        . /home/vagrant/.profile
+            # Source the .profile to pick up changes
+            . /home/vagrant/.profile
+        fi
     fi
-
 fi

--- a/scripts/laravel.sh
+++ b/scripts/laravel.sh
@@ -3,10 +3,14 @@
 echo ">>> Installing Laravel"
 
 # Test if PHP is installed
-php -v > /dev/null 2>&1 || { printf "!!! PHP is not installed.\n    Installing Laravel aborted!\n"; exit 0; }
+php -v > /dev/null 2>&1
+PHP_IS_INSTALLED=$?
 
-# Test if Composer is installed
-composer -v > /dev/null 2>&1 || { printf "!!! Composer is not installed.\n    Installing Laravel aborted!\n"; exit 0; }
+# Test if HHVM is installed
+hhvm --version > /dev/null 2>&1
+HHVM_IS_INSTALLED=$?
+
+[[ $HHVM_IS_INSTALLED -ne 0 && $PHP_IS_INSTALLED -ne 0 ]] && { printf "!!! PHP/HHVM is not installed.\n    Installing Laravel aborted!\n"; exit 0; }
 
 # Test if Composer is installed
 composer -v > /dev/null 2>&1 || { printf "!!! Composer is not installed.\n    Installing Laravel aborted!"; exit 0; }
@@ -15,21 +19,17 @@ composer -v > /dev/null 2>&1 || { printf "!!! Composer is not installed.\n    In
 [[ -z "$1" ]] && { printf "!!! IP address not set. Check the Vagrantfile.\n    Installing Laravel aborted!\n"; exit 0; }
 
 # Check if Laravel root is set. If not set use default
-if [ -z "$2" ]; then
+if [[ -z $2 ]]; then
     laravel_root_folder="/vagrant/laravel"
 else
     laravel_root_folder="$2"
 fi
 
-if [ -z "$3" ]; then
+if [[ -z $3 ]]; then
     laravel_public_folder="$laravel_root_folder/public"
 else
     laravel_public_folder="$3"
 fi
-
-# Test if HHVM is installed
-hhvm --version > /dev/null 2>&1
-HHVM_IS_INSTALLED=$?
 
 # Test if Apache or Nginx is installed
 nginx -v > /dev/null 2>&1
@@ -39,20 +39,23 @@ apache2 -v > /dev/null 2>&1
 APACHE_IS_INSTALLED=$?
 
 # Create Laravel folder if needed
-if [ ! -d $laravel_root_folder ]; then
+if [[ ! -d $laravel_root_folder ]]; then
     mkdir -p $laravel_root_folder
 fi
 
-if [ ! -f "$laravel_root_folder/composer.json" ]; then
-    # Create Laravel
-    if [ $HHVM_IS_INSTALLED -eq 0 ]; then
-        if [ "$4" == 'latest-stable' ]; then
-            hhvm /usr/local/bin/composer create-project --prefer-dist laravel/laravel $laravel_root_folder
+if [[ ! -f "$laravel_root_folder/composer.json" ]]; then
+    if [[ $HHVM_IS_INSTALLED -eq 0 ]]; then
+        # Create Laravel
+        if [[ "$4" == 'latest-stable' ]]; then
+            hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 -v Eval.Jit=false /usr/local/bin/composer \
+            create-project --prefer-dist laravel/laravel $laravel_root_folder
         else
-            hhvm /usr/local/bin/composer create-project laravel/laravel:$4 $laravel_root_folder
+            hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 -v Eval.Jit=false /usr/local/bin/composer \
+            create-project laravel/laravel:$4 $laravel_root_folder
         fi
     else
-        if [ "$4" == 'latest-stable' ]; then
+        # Create Laravel
+        if [[ "$4" == 'latest-stable' ]]; then
             composer create-project --prefer-dist laravel/laravel $laravel_root_folder
         else
             composer create-project laravel/laravel:$4 $laravel_root_folder
@@ -62,9 +65,9 @@ else
     # Go to vagrant folder
     cd $laravel_root_folder
 
-    # Install Laravel
-    if [ $HHVM_IS_INSTALLED -eq 0 ]; then
-        hhvm /usr/local/bin/composer install --prefer-dist
+    if [[ $HHVM_IS_INSTALLED -eq 0 ]]; then
+        hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 -v Eval.Jit=false /usr/local/bin/composer \
+        install --prefer-dist
     else
         composer install --prefer-dist
     fi
@@ -73,7 +76,7 @@ else
     cd -
 fi
 
-if [ $NGINX_IS_INSTALLED -eq 0 ]; then
+if [[ $NGINX_IS_INSTALLED -eq 0 ]]; then
     nginx_root=$(echo "$laravel_public_folder" | sed 's/\//\\\//g')
 
     # Change default vhost created
@@ -81,7 +84,7 @@ if [ $NGINX_IS_INSTALLED -eq 0 ]; then
     sudo service nginx reload
 fi
 
-if [ $APACHE_IS_INSTALLED -eq 0 ]; then
+if [[ $APACHE_IS_INSTALLED -eq 0 ]]; then
     # Remove apache vhost from default and create a new one
     rm /etc/apache2/sites-enabled/$1.xip.io.conf > /dev/null 2>&1
     rm /etc/apache2/sites-available/$1.xip.io.conf > /dev/null 2>&1


### PR DESCRIPTION
I am not sure why but I couldn't simply resource .profile so I could use the composer alias while provisioning. Once done and logged in the alias does work.
