### PR TITLE
create additional vhost for offline times

### DIFF
--- a/scripts/apache.sh
+++ b/scripts/apache.sh
@@ -38,6 +38,11 @@ sudo mv vhost /usr/local/bin
 # Create a virtualhost to start, with SSL certificate
 sudo vhost -s $1.xip.io -d $public_folder -p /etc/ssl/xip.io -c xip.io -a $3
 
+# Create virtualhost for hostname
+# This will allow to access via the hostname,
+# when ip_address hostname is added to the hosts file
+sudo vhost -s $3 -d $public_folder -a $3
+
 if [[ $PHP_IS_INSTALLED -eq 0 ]]; then
 
     # PHP Config for Apache


### PR DESCRIPTION
Allow connecting to the virtual server when unable to connect to xip.io (Requires manual insert into the hosts file. eg. 1027.0.0.1 vaprobash.dev).
