### PR TITLE
Adding Swap to Vaprobash

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,7 @@ hostname        = "vaprobash.dev"
 #   192.168.0.1 - 192.168.255.254
 server_ip             = "192.168.22.10"
 server_memory         = "384" # MB
+server_swap           = "768" # Options: false | int (MB) - Guideline: Between one or two times the server_memory
 server_timezone       = "UTC"
 
 # Database Configuration
@@ -126,11 +127,10 @@ Vagrant.configure("2") do |config|
   ##########
 
   # Provision Base Packages
-  config.vm.provision "shell", path: "#{github_url}/scripts/base.sh", args: github_url
+  config.vm.provision "shell", path: "#{github_url}/scripts/base.sh", args: [github_url, server_swap]
 
   # Provision PHP
   config.vm.provision "shell", path: "#{github_url}/scripts/php.sh", args: [server_timezone, hhvm]
-
 
   # Enable MSSQL for PHP
   # config.vm.provision "shell", path: "#{github_url}/scripts/mssql.sh"

--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -46,3 +46,37 @@ sudo mkdir -p "$SSL_DIR"
 sudo openssl genrsa -out "$SSL_DIR/xip.io.key" 1024
 sudo openssl req -new -subj "$(echo -n "$SUBJ" | tr "\n" "/")" -key "$SSL_DIR/xip.io.key" -out "$SSL_DIR/xip.io.csr" -passin pass:$PASSPHRASE
 sudo openssl x509 -req -days 365 -in "$SSL_DIR/xip.io.csr" -signkey "$SSL_DIR/xip.io.key" -out "$SSL_DIR/xip.io.crt"
+
+# Setting up Swap
+
+# Disable case sensitivity
+shopt -s nocasematch
+
+if [[ ! -z $2 && ! $2 =~ false && $2 =~ ^[0-9]*$ ]]; then
+
+    echo ">>> Setting up Swap ($2 MB)"
+
+    # Create the Swap file
+    fallocate -l $2M /swapfile
+
+    # Set the correct Swap permissions
+    chmod 600 /swapfile
+
+    # Setup Swap space
+    mkswap /swapfile
+
+    # Enable Swap space
+    swapon /swapfile
+
+    # Make the Swap file permanent
+    echo "/swapfile   none    swap    sw    0   0" | tee -a /etc/fstab
+
+    # Add some swap settings:
+    # vm.swappiness=10: Means that there wont be a Swap file until memory hits 90% useage
+    # vm.vfs_cache_pressure=50: read http://rudd-o.com/linux-and-free-software/tales-from-responsivenessland-why-linux-feels-slow-and-how-to-fix-that
+    printf "vm.swappiness=10\nvm.vfs_cache_pressure=50" | tee -a /etc/sysctl.conf && sysctl -p
+
+fi
+
+# Enable case sensitivity
+shopt -u nocasematch


### PR DESCRIPTION
- See #338
- Adds optional Swap to the Vagrant box using a new variable called `server_swap`. Set it to `false` if you don't want any Swap.
- Will fix #336
