### PR TITLE
Installing the newer version

### DIFF
--- a/scripts/mongodb.sh
+++ b/scripts/mongodb.sh
@@ -11,7 +11,7 @@ sudo apt-get update
 
 # Install MongoDB
 # -qq implies -y --force-yes
-sudo apt-get install -qq mongodb-10gen
+sudo apt-get install -qq mongodb-org
 
 # Test if PHP is installed
 php -v > /dev/null 2>&1


### PR DESCRIPTION
When installing the mongoDB, the current script was using the `mongodb-10gen` package. It is the old one. he latest and recommended package to install is `mongodb-org`.

Ref: [Official MongoDB docs](http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/)
