### PR TITLE
Fixed the NVM Installer

### DIFF
--- a/helpers/nvm_install.sh
+++ b/helpers/nvm_install.sh
@@ -22,7 +22,7 @@ SOURCE_STR="\n# This loads NVM\n[[ -s /home/vagrant/.nvm/nvm.sh ]] && . /home/va
 # Append NVM script to ~/.profile
 if ! grep -qsc 'nvm.sh' $PROFILE; then
   echo ">>> Appending source string to $PROFILE"
-  echo $SOURCE_STR >> "$PROFILE"
+  printf "$SOURCE_STR" >> "$PROFILE"
 else
   echo ">>> Source string already in $PROFILE"
 fi


### PR DESCRIPTION
The NVM installer was using 'echo' statement when echoing the string with '\n' in it. 'echo' statement doesn't work with '\n' and thus we have to use printf command. The official installer does use 'printf' itself ([link to official](https://github.com/creationix/nvm/blob/master/install.sh#L126)).

This pull request fixes the issue.
