### PR TITLE
Add g++ as a dependency for mailcatcher

### DIFF
--- a/scripts/mailcatcher.sh
+++ b/scripts/mailcatcher.sh
@@ -12,7 +12,7 @@ APACHE_IS_INSTALLED=$?
 
 # Installing dependency
 # -qq implies -y --force-yes
-sudo apt-get install -qq libsqlite3-dev ruby1.9.1-dev
+sudo apt-get install -qq libsqlite3-dev ruby1.9.1-dev g++
 
 if $(which rvm) -v > /dev/null 2>&1; then
 	echo ">>>>Installing with RVM"


### PR DESCRIPTION
Mailcatcher wouldn't install for me unless I installed g++.

==> Vaprobash: Building native extensions.  This could take a while...
==> Vaprobash: ERROR:  Error installing mailcatcher:
==> Vaprobash:  ERROR: Failed to build gem native extension.
==> Vaprobash:
==> Vaprobash:         /usr/bin/ruby1.9.1 extconf.rb
==> Vaprobash: checking for main() in -lssl... no
==> Vaprobash: checking for rb_trap_immediate in ruby.h,rubysig.h... no
==> Vaprobash: checking for rb_thread_blocking_region()... yes
==> Vaprobash: checking for inotify_init() in sys/inotify.h... yes
==> Vaprobash: checking for writev() in sys/uio.h... yes
==> Vaprobash: checking for rb_wait_for_single_fd()... yes
==> Vaprobash: checking for rb_enable_interrupt()... yes
==> Vaprobash: checking for rb_time_new()... yes
==> Vaprobash: checking for sys/event.h... no
==> Vaprobash: checking for epoll_create() in sys/epoll.h... yes
==> Vaprobash: creating Makefile
==> Vaprobash:
==> Vaprobash: make
==> Vaprobash: compiling kb.cpp
==> Vaprobash: make: g++: Command not found
==> Vaprobash: make: **\* [kb.o] Error 127
==> Vaprobash:
==> Vaprobash:
==> Vaprobash: Gem files will remain installed in /var/lib/gems/1.9.1/gems/eventmachine-1.0.3 for inspection.
==> Vaprobash: Results logged to /var/lib/gems/1.9.1/gems/eventmachine-1.0.3/ext/gem_make.out
==> Vaprobash: update-rc.d: warning: /etc/init.d/cron missing LSB information
==> Vaprobash: update-rc.d: see http://wiki.debian.org/LSBInitScripts
