### PR TITLE
Crontab needs the user defined

### DIFF
--- a/scripts/mailcatcher.sh
+++ b/scripts/mailcatcher.sh
@@ -27,7 +27,7 @@ else
 fi
 
 # Make it start on boot
-sudo echo "@reboot $(which mailcatcher) --ip=0.0.0.0" >> /etc/crontab
+sudo echo "@reboot root $(which mailcatcher) --ip=0.0.0.0" >> /etc/crontab
 sudo update-rc.d cron defaults
 
 if [[ $PHP_IS_INSTALLED -eq 0 ]]; then


### PR DESCRIPTION
Mailcatcher wasn't starting for me automatically after a vagrant halt && vagrant up.

The system crontab requires the user to be defined.
