### PR TITLE
Added docker provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -171,6 +171,9 @@ Vagrant.configure("2") do |config|
   # Provision Vim
   # config.vm.provision "shell", path: "#{github_url}/scripts/vim.sh", args: github_url
 
+  # Provision Docker
+  # config.vm.provision "shell", path: "#{github_url}/scripts/docker.sh"
+
 
   ####
   # Web Servers

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ Here's a quickstart screencast!
 	* Vim
 	* PHP MsSQL (ability to connect to SQL Server)
 	* Screen
+	* Docker
 * Web Servers
 	* Apache
 	* HHVM

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+echo ">>> Installing Docker"
+
+# Add Key
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+
+# Add Repository
+sudo sh -c "echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
+sudo apt-get update
+
+# Install Docker
+# -qq implies -y --force-yes
+sudo apt-get install -qq lxc-docker


### PR DESCRIPTION
Allows you to install latest docker, avoiding the "stale" ~0.9 version currently available from trusty packages.

I wasn't sure about which section of the `Vagrantfile` and `readme.md` this should go into, if you'd like it updated please let me know.
