### PR TITLE
Added an option to use PHP 5.5.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,6 +37,7 @@ mongo_enable_remote   = "false"  # remote access enabled when true
 
 # Languages and Packages
 php_timezone          = "UTC"    # http://php.net/manual/en/timezones.php
+php_version           = "5.6"    # Options: 5.5 | 5.6
 ruby_version          = "latest" # Choose what ruby version should be installed (will also be the default version)
 ruby_gems             = [        # List any Ruby Gems that you want to install
   #"jekyll",
@@ -172,7 +173,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: "#{github_url}/scripts/base_box_optimizations.sh", privileged: true
 
   # Provision PHP
-  config.vm.provision "shell", path: "#{github_url}/scripts/php.sh", args: [php_timezone, hhvm]
+  config.vm.provision "shell", path: "#{github_url}/scripts/php.sh", args: [php_timezone, hhvm, php_version]
 
   # Enable MSSQL for PHP
   # config.vm.provision "shell", path: "#{github_url}/scripts/mssql.sh"

--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -4,6 +4,7 @@ export LANG=C.UTF-8
 
 PHP_TIMEZONE=$1
 HHVM=$2
+PHP_VERSION=$3
 
 if [[ $HHVM == "true" ]]; then
 
@@ -28,10 +29,17 @@ if [[ $HHVM == "true" ]]; then
 
     sudo service hhvm restart
 else
-    echo ">>> Installing PHP"
+    echo ">>> Installing PHP $PHP_VERSION"
 
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C
-    sudo add-apt-repository -y ppa:ondrej/php5-5.6
+
+    if [ $PHP_VERSION == "5.5" ]; then
+        # Add repo for PHP 5.5
+        sudo add-apt-repository -y ppa:ondrej/php5
+    else
+        # Add repo for PHP 5.6
+        sudo add-apt-repository -y ppa:ondrej/php5-5.6
+    fi
 
     sudo apt-key update
     sudo apt-get update


### PR DESCRIPTION
Based on issue #417 

Inside the `Vagrantfile` you can specify which version of php you would like installed

```
php_version           = "5.6"    # Options: 5.5 | 5.6
```
