### PR TITLE
Install build-essential with mongodb

### DIFF
--- a/scripts/mongodb.sh
+++ b/scripts/mongodb.sh
@@ -11,7 +11,7 @@ sudo apt-get update
 
 # Install MongoDB
 # -qq implies -y --force-yes
-sudo apt-get install -qq mongodb-org
+sudo apt-get install -qq mongodb-org build-essential
 
 # Make MongoDB connectable from outside world without SSH tunnel
 if [ $1 == "true" ]; then


### PR DESCRIPTION
When working with mongodb many users will also need to install the c++ bson library (either through npm or other means)

For this extension to properly install, `build-essential` (along with make and gcc) are required.

Otherwise everyone is left in the cold with a slow native js version of the bson interpreter!

And no one likes things that are slow!

Slow BSON makes people :arrow_down: 
![Slow is bad](http://mashable.com/wp-content/uploads/2013/07/Dr.-Who.gif)
