### PR TITLE
Add forwarded_port for access via LAN/WAN

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -98,6 +98,7 @@ Vagrant.configure("2") do |config|
 
   # Create a static IP
   config.vm.network :private_network, ip: server_ip
+  config.vm.network :forwarded_port, guest: 80, host: 8000
 
   # Use NFS for the shared folder
   config.vm.synced_folder ".", "/vagrant",


### PR DESCRIPTION
This adds the possibility of accessing the VM via LAN or WAN. Useful for allowing someone to view a page or site without having to install or run anything apart from a browser.

### LAN
Possible to use this (for example): devicetest.192.168.1.50.xip.io:8000
While adding "devicetest.192.168.1.50.xip.io" into the server_name in nginx or ServerName in Apache.

### WAN
You would have to use the external IP address to access it, allow through firewall or router and it will work.

Mentioned on issue: #384