### PR TITLE
Add mailhog script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -304,6 +304,9 @@ Vagrant.configure("2") do |config|
   # Install Mailcatcher
   # config.vm.provision "shell", path: "#{github_url}/scripts/mailcatcher.sh"
 
+  # Install Mailhog
+  # config.vm.provision "shell", path: "#{github_url}/scripts/mailhog.sh"
+
   # Install git-ftp
   # config.vm.provision "shell", path: "#{github_url}/scripts/git-ftp.sh", privileged: false
 

--- a/scripts/mailhog.sh
+++ b/scripts/mailhog.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+echo ">>> Installing Mailhog"
+
+# Download binary from github
+wget --quiet -O ~/mailhog https://github.com/mailhog/MailHog/releases/download/v0.1.3/MailHog_linux_amd64
+
+# Make it executable
+chmod +x ~/mailhog
+
+# Make it start on reboot
+sudo tee /etc/init/mailhog.conf <<EOL
+description "Mailhog"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+pre-start script
+	exec su - vagrant -c "/usr/bin/env ~/mailhog > /dev/null 2>&1 &"
+end script
+EOL
+
+# Start it now
+sudo service mailhog start


### PR DESCRIPTION
Adds bash script for installing Mailhog ( https://github.com/mailhog/MailHog ), an alternative for Mailcatcher.
- Doesn't require any special dependencies like Ruby for mailcatcher. 
- Installation is very fast.
- Just download a binary file from the github repository and run it. 
