### PR TITLE
Update package list before installing Jre and use latest version of elasticsearch

### DIFF
--- a/scripts/elasticsearch.sh
+++ b/scripts/elasticsearch.sh
@@ -7,6 +7,7 @@ ELASTICSEARCH_VERSION=1.0.0 # Check http://www.elasticsearch.org/download/ for l
 
 # Install prerequisite: Java
 # -qq implies -y --force-yes
+sudo apt-get update
 sudo apt-get install -qq openjdk-7-jre-headless
 
 wget --quiet https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.deb

--- a/scripts/elasticsearch.sh
+++ b/scripts/elasticsearch.sh
@@ -3,7 +3,7 @@
 echo ">>> Installing Elasticsearch"
 
 # Set some variables
-ELASTICSEARCH_VERSION=1.0.0 # Check http://www.elasticsearch.org/download/ for latest version
+ELASTICSEARCH_VERSION=1.4.2 # Check http://www.elasticsearch.org/download/ for latest version
 
 # Install prerequisite: Java
 # -qq implies -y --force-yes


### PR DESCRIPTION
I was unable to get Elasticsearch installed on the latest version Laravel Homestead using Vaprobash as the Jre was trying to get libnss3-nssdb_3.17.1-0ubuntu0.14.04.1_all.deb which no longer exists (now libnss3-nssdb_3.17.1-0ubuntu0.14.04.2_all.deb).

A simple apt-get update before the install fixes the issue :)