### PR TITLE
Fix retrieval of latest NodeJS version

### DIFF
--- a/scripts/nodejs.sh
+++ b/scripts/nodejs.sh
@@ -45,7 +45,7 @@ if [[ $NODE_IS_INSTALLED -ne 0 ]]; then
 
     # If set to latest, get the current node version from the home page
     if [[ $NODEJS_VERSION -eq "latest" ]]; then
-        NODEJS_VERSION=`curl 'nodejs.org' | grep 'Current Version' | awk '{ print $4 }' | awk -F\< '{ print $1 }'`
+        NODEJS_VERSION=`curl 'https://nodejs.org' | grep 'Current Version' | awk '{ print $4 }' | awk -F\< '{ print $1 }'`
     fi
 
     # Install Node


### PR DESCRIPTION
The previous URL did not return anything (apparently Node changed to HTTPS at some point), which caused the Node installation to fail for me (using version "latest").