### PR TITLE
nodejs install fails due to nodejs.org redirect

### DIFF
--- a/scripts/nodejs.sh
+++ b/scripts/nodejs.sh
@@ -45,7 +45,7 @@ if [[ $NODE_IS_INSTALLED -ne 0 ]]; then
 
     # If set to latest, get the current node version from the home page
     if [[ $NODEJS_VERSION -eq "latest" ]]; then
-        NODEJS_VERSION=`curl 'nodejs.org' | grep 'Current Version' | awk '{ print $4 }' | awk -F\< '{ print $1 }'`
+        NODEJS_VERSION=`curl -L 'nodejs.org' | grep 'Current Version' | awk '{ print $4 }' | awk -F\< '{ print $1 }'`
     fi
 
     # Install Node


### PR DESCRIPTION
Looks like nodejs.org responds with a 301 redirect now...adding '-L' to curl command that scrapes current version