### PR TITLE
Add vagrant user to docker group

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -188,8 +188,7 @@ Vagrant.configure("2") do |config|
   # config.vm.provision "shell", path: "#{github_url}/scripts/vim.sh", args: github_url
 
   # Provision Docker
-  # config.vm.provision "shell", path: "#{github_url}/scripts/docker.sh"
-
+  # config.vm.provision "shell", path: "#{github_url}/scripts/docker.sh", args: "permissions"
 
   ####
   # Web Servers

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -12,3 +12,13 @@ sudo apt-get update
 # Install Docker
 # -qq implies -y --force-yes
 sudo apt-get install -qq lxc-docker
+
+# Make the vagrant user able to interact with docker without sudo
+if [ ! -z "$1" ]; then
+	if [ "$1" == "permissions" ]; then
+		echo ">>> Adding vagrant user to docker group"
+
+		sudo usermod -a -G docker vagrant
+
+	fi # permissions
+fi # arg check


### PR DESCRIPTION
Added a new option (defaulted to enabled for new users) which adds the vagrant user to the docker group.

This enables the user to run commands against docker, without having to invoke sudo.