### PR TITLE
Fixes the npm latest installer to get latest version of node correctly

### DIFF
--- a/scripts/nodejs.sh
+++ b/scripts/nodejs.sh
@@ -45,7 +45,7 @@ if [[ $NODE_IS_INSTALLED -ne 0 ]]; then
 
     # If set to latest, get the current node version from the home page
     if [[ $NODEJS_VERSION -eq "latest" ]]; then
-        NODEJS_VERSION=`curl -L 'nodejs.org' | grep 'Current Version' | awk '{ print $4 }' | awk -F\< '{ print $1 }'`
+        NODEJS_VERSION=`curl -L 'nodejs.org' | grep 'Current Version' | awk '{ print $3 }' | awk -F\< '{ print $1 }'`
     fi
 
     # Install Node


### PR DESCRIPTION
Fixes https://github.com/fideloper/Vaprobash/issues/471

`nodejs.org` has changed their formatting again slightly.

With the current version, the command returns nothing:
```
 ~/its-a-box/Projects/Vaprobash   master ± curl -L 'nodejs.org' | grep 'Current Version' | awk '{ print $4 }' | awk -F\< '{ print $1 }'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   178  100   178    0     0    105      0  0:00:01  0:00:01 --:--:--   105
100  7528  100  7528    0     0   3828      0  0:00:01  0:00:01 --:--:--  3828

```

Patched, it correctly returns v0.12.6:
```
~/its-a-box/Projects/Vaprobash   master  curl -L 'nodejs.org' | grep 'Current Version' | awk '{ print $3 }' | awk -F\< '{ print $1 }'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   178  100   178    0     0     98      0  0:00:01  0:00:01 --:--:--    98
100  7528  100  7528    0     0   2956      0  0:00:02  0:00:02 --:--:-- 57030
v0.12.6
```