### PR TITLE
Removes oh-my-zsh from documentation

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,7 +2,6 @@
     <h3>Install Scripts</h3>
     <div class="list-group">
         <a href="install-scripts.html#base" class="list-group-item">Base</a>
-        <a href="install-scripts.html#oh-my-zsh" class="list-group-item">Oh-My-Zsh</a>
         <a href="install-scripts.html#php" class="list-group-item">PHP</a>
         <a href="install-scripts.html#vim" class="list-group-item">Vim</a>
         <a href="install-scripts.html#screen" class="list-group-item">Screen</a>

--- a/install-scripts.md
+++ b/install-scripts.md
@@ -18,12 +18,6 @@ This installs some basics items.
 - build-essential, python-software-properties
 - SSL certificate (self-signed) for [#](https://*.xip.io) addresses
 
-### <a href="install-scripts.html#oh-my-zsh" name="oh-my-zsh" id="oh-my-zsh">#</a> Oh-My-Zsh
-
-This installs ZSH and runs the [installer for Oh-My-Zsh](https://gist.github.com/tsabat/1498393).
-
-<p class="alert alert-danger">This install may be deleted, as Oh-My-Zsh appears to edit the users PATH variable, causing issues with the installation of other scripts.</p>
-
 ### <a href="install-scripts.html#base" name="php" id="php">#</a> PHP
 
 This will install PHP 5.5 and its common modules. This also install xdebug and sets the following:


### PR DESCRIPTION
In light of https://github.com/fideloper/Vaprobash/commit/7c234ad58127f53dc52bc2e36a6306f1dc40fa6b this commit removes `oh-my-zsh` from the docs.