### PR TITLE
Replicate local ~/.gitconfig

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,6 +118,9 @@ Vagrant.configure("2") do |config|
             :nfs => true,
             :mount_options => ['nolock,vers=3,udp,noatime']
 
+  # Replicate local ~/.gitconfig
+  config.vm.provision "file", source: "~/.gitconfig", destination: ".gitconfig"
+
   # If using VirtualBox
   config.vm.provider :virtualbox do |vb|
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,15 +111,17 @@ Vagrant.configure("2") do |config|
 
   # Enable agent forwarding over SSH connections
   config.ssh.forward_agent = true
-  
+
   # Use NFS for the shared folder
   config.vm.synced_folder ".", "/vagrant",
             id: "core",
             :nfs => true,
             :mount_options => ['nolock,vers=3,udp,noatime']
 
-  # Replicate local ~/.gitconfig
-  config.vm.provision "file", source: "~/.gitconfig", destination: ".gitconfig"
+  # Replicate local .gitconfig file if it exists
+  if File.file?(File.expand_path("~/.gitconfig"))
+    config.vm.provision "file", source: "~/.gitconfig", destination: ".gitconfig"
+  end
 
   # If using VirtualBox
   config.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
Replicate local `~/.gitconfig` to the Vagrant user's home directory on the guest machine so you won't have to run `git config --global` every time you provision a new VM.