### PR TITLE
Fixed non valid quotation marks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -310,7 +310,7 @@ Vagrant.configure("2") do |config|
 
   # Provision Composer
   # You may pass a github auth token as the first argument
-  # config.vm.provision "shell", path: "#{github_url}/scripts/composer.sh", privileged: false, args: [“”, composer_packages.join(" “)]
+  # config.vm.provision "shell", path: "#{github_url}/scripts/composer.sh", privileged: false, args: ["", composer_packages.join(" ")]
 
   # Provision Laravel
   # config.vm.provision "shell", path: "#{github_url}/scripts/laravel.sh", privileged: false, args: [server_ip, laravel_root_folder, public_folder, laravel_version]


### PR DESCRIPTION
Apparently, some quotation marks with another encoding was used and that caused a syntax error when trying to provision Composer.