### PR TITLE
fix: MySQL 5.6 bind address

### DIFF
--- a/scripts/mysql.sh
+++ b/scripts/mysql.sh
@@ -30,7 +30,11 @@ sudo apt-get install -qq $mysql_package
 if [ $3 == "true" ]; then
     # enable remote access
     # setting the mysql bind-address to allow connections from everywhere
-    sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
+    if [ $2 == "5.6" ]; then
+        sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf
+    else
+        sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
+    fi
 
     # adding grant privileges to mysql root user from everywhere
     # thx to http://stackoverflow.com/questions/7528967/how-to-grant-mysql-privileges-in-a-bash-script for this


### PR DESCRIPTION
MySQL has been updated upstream of the PPA used for 5.6. These changes introduce new config file locations, and conf.d directories. The `bind-address` setting which was previously in `/etc/mysql/my.cnf` is now located in `/etc/mysql/mysql.conf.d/mysqld.cnf`.

I have tested this locally with Vaprobash set to install both "5.5" and "5.6" MySQL versions to verify I didn't break 5.5 support inadvertently.