### PR TITLE
Remove custom NPM package prefix

### DIFF
--- a/scripts/nodejs.sh
+++ b/scripts/nodejs.sh
@@ -56,19 +56,6 @@ if [[ $NODE_IS_INSTALLED -ne 0 ]]; then
 
     nvm use default
 
-    echo ">>> Starting to config Node.js"
-
-    # Change where npm global packages are located
-    npm config set prefix /home/vagrant/npm
-
-    if [[ -f "/home/vagrant/.profile" ]]; then
-        # Add new NPM Global Packages location to PATH (.profile)
-        printf "\n# Add new NPM global packages location to PATH\n%s" 'export PATH=$PATH:~/npm/bin' >> /home/vagrant/.profile
-
-        # Add new NPM root to NODE_PATH (.profile)
-        printf "\n# Add the new NPM root to NODE_PATH\n%s" 'export NODE_PATH=$NODE_PATH:~/npm/lib/node_modules' >> /home/vagrant/.profile
-    fi
-
 fi
 
 # Install (optional) Global Node Packages


### PR DESCRIPTION
NVM hasn't worked well with the NPM "prefix" option. They added a warning about this in a release seven days ago.

Since global packages are already in the PATH (NVM probably takes care of that), just removing the custom prefix did the job for me. Are there any problems this could cause?

See https://github.com/creationix/nvm/issues/606 and https://github.com/creationix/nvm/commit/a1def710628a2fc71552a9f79f9b53f3d6a3b8db