### PR TITLE
NodeJS: Fix fetching of latest version number

### DIFF
--- a/scripts/nodejs.sh
+++ b/scripts/nodejs.sh
@@ -45,7 +45,7 @@ if [[ $NODE_IS_INSTALLED -ne 0 ]]; then
 
     # If set to latest, get the current node version from the home page
     if [[ $NODEJS_VERSION -eq "latest" ]]; then
-        NODEJS_VERSION=`curl -L 'nodejs.org' | grep 'Current Version' | awk '{ print $4 }' | awk -F\< '{ print $1 }'`
+        NODEJS_VERSION=`curl -L 'nodejs.org' | grep 'Current Version' | awk '{ print $3 }' | awk -F\< '{ print $1 }'`
     fi
 
     # Install Node


### PR DESCRIPTION
Apparently, they changed something again. Download only works like that for me (when using "latest").