### PR TITLE
fix: nodejs version detection

### DIFF
--- a/scripts/nodejs.sh
+++ b/scripts/nodejs.sh
@@ -45,7 +45,7 @@ if [[ $NODE_IS_INSTALLED -ne 0 ]]; then
 
     # If set to latest, get the current node version from the home page
     if [[ $NODEJS_VERSION -eq "latest" ]]; then
-        NODEJS_VERSION=`curl -L 'nodejs.org' | grep 'Current Version' | awk '{ print $4 }' | awk -F\< '{ print $1 }'`
+        NODEJS_VERSION=`curl -L 'nodejs.org' | grep -Po 'Current Version: v(\d).(\d).(\d)' | awk '{print $3}'`
     fi
 
     # Install Node


### PR DESCRIPTION
This commit adds a more forgiving version detection to the nodejs install script.

I took a look at the internet archive for nodejs.org. It looks like the primary different between the current version of the nodejs.org site, and historical versions of the site are as follows:

**Current:**
```
<p class="home-version home-version-banner">
    Current Version: v4.2.0<br>
    <a href="https://nodejs.org/en/blog/release/v4.2.0/">Long Term Support Release</a>
</p>
```

**Sept 10:** http://web.archive.org/web/20150910152006/https://nodejs.org/en/
```
<p class="home-version">Current Version: v4.0.0</p>
```

This updated regex matches both cases, since we've seen the nodejs.org DOM change back within a few days in the past.

**Current:**
```
 vagrant@vaprobash  ~ 
 curl -L 'nodejs.org' | grep -Po 'Current Version: v(\d).(\d).(\d)' | awk '{print $3}'
v4.2.0
```

**Current, with echo:**
```
 vagrant@vaprobash  ~ 
  echo "Current Version: v4.2.0<br>" | grep -Po 'Current Version: v(\d).(\d).(\d)' | awk '{print $3}'
v4.2.0
```

**Legacy, tested via echo:**
```
 vagrant@vaprobash  ~ 
  echo "<p class="home-version">Current Version: v4.0.0</p>" | grep -Po 'Current Version: v(\d).(\d).(\d)' | awk '{print $3}'
v4.0.0
```

With a little luck on our side, this will reduce the number of breakages introduced by DOM changes to the nodejs.org site.

Fixes https://github.com/fideloper/Vaprobash/issues/506