### PR TITLE
Add support for PHP mongodb extension

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,7 @@ mysql_enable_remote   = "false"  # remote access enabled when true
 pgsql_root_password   = "root"   # We'll assume user "root"
 mongo_version         = "2.6"    # Options: 2.6 | 3.0
 mongo_enable_remote   = "false"  # remote access enabled when true
+mongo_php_ext         = "mongo"  # Set to 'mongodb' to use the modern mongodb extension
 
 # Languages and Packages
 php_timezone          = "UTC"    # http://php.net/manual/en/timezones.php
@@ -244,7 +245,7 @@ Vagrant.configure("2") do |config|
   # config.vm.provision "shell", path: "#{github_url}/scripts/couchdb.sh"
 
   # Provision MongoDB
-  # config.vm.provision "shell", path: "#{github_url}/scripts/mongodb.sh", args: [mongo_enable_remote, mongo_version]
+  # config.vm.provision "shell", path: "#{github_url}/scripts/mongodb.sh", args: [mongo_enable_remote, mongo_version, mongo_php_ext]
 
   # Provision MariaDB
   # config.vm.provision "shell", path: "#{github_url}/scripts/mariadb.sh", args: [mysql_root_password, mysql_enable_remote]

--- a/scripts/mongodb.sh
+++ b/scripts/mongodb.sh
@@ -33,17 +33,17 @@ PHP_IS_INSTALLED=$?
 
 if [ $PHP_IS_INSTALLED -eq 0 ]; then
     # install dependencies
-    sudo apt-get -y install php-pear php5-dev
+    sudo apt-get -y install php-pear php5-dev pkg-config libssl-dev
 
     # install php extension
     echo "no" > answers.txt
-    sudo pecl install mongo < answers.txt
+    sudo pecl install $3 < answers.txt
     rm answers.txt
 
     # add extension file and restart service
-    echo 'extension=mongo.so' | sudo tee /etc/php5/mods-available/mongo.ini
+    echo "extension=$3.so" | sudo tee /etc/php5/mods-available/$3.ini
 
-    ln -s /etc/php5/mods-available/mongo.ini /etc/php5/fpm/conf.d/mongo.ini
-    ln -s /etc/php5/mods-available/mongo.ini /etc/php5/cli/conf.d/mongo.ini
+    ln -s /etc/php5/mods-available/$3.ini /etc/php5/fpm/conf.d/20-$3.ini
+    ln -s /etc/php5/mods-available/$3.ini /etc/php5/cli/conf.d/20-$3.ini
     sudo service php5-fpm restart
 fi


### PR DESCRIPTION
This adds support for the mongodb PHP extension which replaces the old mongo extension. The default is still the old extension which can be changed with a variable.

Again, since the default is the extension which is currently installed, I hope this counts as a minor feature and gets in quickly.