### PR TITLE
Use auto network only if hostmanager is installed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,8 +108,9 @@ Vagrant.configure("2") do |config|
   # TO DO: Make this work with virtualhost along-side xip.io URL
   config.vm.hostname = hostname
 
-  # Create a static IP
-  if Vagrant.has_plugin?("vagrant-auto_network")
+  # Create a static IP. Use auto network only if hostmanager is installed as
+  # well as it is not straight-forward to figure out the assigned IP address.
+  if Vagrant.has_plugin?("vagrant-auto_network") and Vagrant.has_plugin?("vagrant-hostmanager")
     config.vm.network :private_network, :ip => "0.0.0.0", :auto_network => true
   else
     config.vm.network :private_network, ip: server_ip


### PR DESCRIPTION
On my machine, hostmanager does not work very well and I removed it. Auto network still stayed around. The problem is that even if I assign a specific address and hostname in the `Vagrantfile` in the `server_ip` setting, neither works. I have to figure out the IP address assigned by auto network and then use that.

IMHO, this is a bug as neither config options `server_ip` and `hostname` work in this scenario. The change in PR should fix the issue by using auto_network only if hostmanager is also installed (so that at least `hostname` can be used).