### PR TITLE
Fix installation of Mailcatcher using RVM and non-RVM

### DIFF
--- a/scripts/mailcatcher.sh
+++ b/scripts/mailcatcher.sh
@@ -10,15 +10,24 @@ PHP_IS_INSTALLED=$1
 apache2 -v > /dev/null 2>&1
 APACHE_IS_INSTALLED=$?
 
-# Installing dependency
+# Source .profile for RVM, if available
+if [[ -f "/home/vagrant/.profile" ]]; then
+	source /home/vagrant/.profile
+fi
+
+# Installing sqlite dependency
 # -qq implies -y --force-yes
-sudo apt-get install -qq libsqlite3-dev ruby1.9.1-dev
+sudo apt-get install -qq libsqlite3-dev
 
 if $(which rvm) -v > /dev/null 2>&1; then
 	echo ">>>>Installing with RVM"
 	$(which rvm) default@mailcatcher --create do gem install --no-rdoc --no-ri mailcatcher
 	$(which rvm) wrapper default@mailcatcher --no-prefix mailcatcher catchmail
 else
+	# Installing ruby dependency
+	# -qq implies -y --force-yes
+	sudo apt-get install -qq ruby-2.0.0-dev
+
 	# Gem check
 	if ! gem -v > /dev/null 2>&1; then sudo aptitude install -y libgemplugin-ruby; fi
 

--- a/scripts/mailcatcher.sh
+++ b/scripts/mailcatcher.sh
@@ -26,13 +26,23 @@ if $(which rvm) -v > /dev/null 2>&1; then
 else
 	# Installing ruby dependency
 	# -qq implies -y --force-yes
-	sudo apt-get install -qq ruby-2.0.0-dev
+	sudo apt-get install -qq ruby1.9.1-dev
 
 	# Gem check
 	if ! gem -v > /dev/null 2>&1; then sudo aptitude install -y libgemplugin-ruby; fi
 
+	# Install Mailcatcher gem dependencies, otherwise Ruby 2.0.0+ is required
+	gem install --no-rdoc --no-ri mail -v 2.6.3 # Last known working with Ruby < 2.0.0
+	gem install --no-rdoc --no-ri activesupport -v "~> 4.0"
+	gem install --no-rdoc --no-ri eventmachine -v 1.0.9.1
+	gem install --no-rdoc --no-ri rack -v "~> 1.5"
+	gem install --no-rdoc --no-ri sinatra -v "~> 1.2"
+	gem install --no-rdoc --no-ri skinny -v "~> 0.2.3"
+	gem install --no-rdoc --no-ri sqlite3 -v "~> 1.3"
+	gem install --no-rdoc --no-ri thin -v "~> 1.5.0"
+
 	# Install
-	gem install --no-rdoc --no-ri mailcatcher
+	gem install --no-rdoc --no-ri --ignore-dependencies mailcatcher -v "~> 0.6"
 fi
 
 # Make it start on boot


### PR DESCRIPTION
This fixes #560 

If you try to install Mailcatcher and you have RVM installed, `$(which rvm)` never returns the rvm installation, sourcing /home/vagrant/.profile resets the RVM paths

The non-RVM version fixes the dependency issue on the mail gem bump from [2.6.3](https://rubygems.org/gems/mail/versions/2.6.3) -> [2.6.4](https://rubygems.org/gems/mail/versions/2.6.4) causing the mime-types to be [>= 3.0+](https://rubygems.org/gems/mime-types/versions/3.0) from [2.99.2](https://rubygems.org/gems/mime-types/versions/2.99.2) which requires ruby 2.0.0, this will now install the dependencies needed for mailcatcher separately to lock in their working ruby < 2.0.0 versions