### PR TITLE
Upgrade Vaprobash to Ubuntu 16.04 LTS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,9 +2,9 @@
 # vi: set ft=ruby :
 
 # Config Github Settings
-github_username = "fideloper"
+github_username = "Repox"
 github_repo     = "Vaprobash"
-github_branch   = "1.4.2"
+github_branch   = "feature/ubuntu-16.04"
 github_url      = "https://raw.githubusercontent.com/#{github_username}/#{github_repo}/#{github_branch}"
 
 # Because this:https://developer.github.com/changes/2014-12-08-removing-authorizations-token/
@@ -43,7 +43,7 @@ mongo_enable_remote   = "false"  # remote access enabled when true
 
 # Languages and Packages
 php_timezone          = "UTC"    # http://php.net/manual/en/timezones.php
-php_version           = "5.6"    # Options: 5.5 | 5.6 | 7.0 | 7.1
+php_version           = "7.1"    # Options: 5.6 | 7.0 | 7.1
 ruby_version          = "latest" # Choose what ruby version should be installed (will also be the default version)
 ruby_gems             = [        # List any Ruby Gems that you want to install
   #"jekyll",
@@ -91,8 +91,8 @@ elasticsearch_version = "2.3.1" # 5.0.0-alpha1, 2.3.1, 2.2.2, 2.1.2, 1.7.5
 
 Vagrant.configure("2") do |config|
 
-  # Set server to Ubuntu 14.04
-  config.vm.box = "ubuntu/trusty64"
+  # Set server to Ubuntu 16.04
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.define "Vaprobash" do |vapro|
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 # Config Github Settings
 github_username = "fideloper"
 github_repo     = "Vaprobash"
-github_branch   = "1.4.2"
+github_branch   = "1.4.4"
 github_url      = "https://raw.githubusercontent.com/#{github_username}/#{github_repo}/#{github_branch}"
 
 # Because this:https://developer.github.com/changes/2014-12-08-removing-authorizations-token/
@@ -35,15 +35,15 @@ server_timezone  = "UTC"
 
 # Database Configuration
 mysql_root_password   = "root"   # We'll assume user "root"
-mysql_version         = "5.5"    # Options: 5.5 | 5.6
+mysql_version         = "5.7"    # Options: 5.6 | 5.7
 mysql_enable_remote   = "false"  # remote access enabled when true
 pgsql_root_password   = "root"   # We'll assume user "root"
-mongo_version         = "2.6"    # Options: 2.6 | 3.0
+mongo_version         = "3.4"    # Options: 3.2 | 3.4
 mongo_enable_remote   = "false"  # remote access enabled when true
 
 # Languages and Packages
 php_timezone          = "UTC"    # http://php.net/manual/en/timezones.php
-php_version           = "5.6"    # Options: 5.5 | 5.6 | 7.0 | 7.1
+php_version           = "7.1"    # Options: 5.6 | 7.0 | 7.1
 ruby_version          = "latest" # Choose what ruby version should be installed (will also be the default version)
 ruby_gems             = [        # List any Ruby Gems that you want to install
   #"jekyll",
@@ -92,7 +92,7 @@ elasticsearch_version = "2.3.1" # 5.0.0-alpha1, 2.3.1, 2.2.2, 2.1.2, 1.7.5
 Vagrant.configure("2") do |config|
 
   # Set server to Ubuntu 14.04
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.define "Vaprobash" do |vapro|
   end
@@ -245,7 +245,7 @@ Vagrant.configure("2") do |config|
   # config.vm.provision "shell", path: "#{github_url}/scripts/couchdb.sh"
 
   # Provision MongoDB
-  # config.vm.provision "shell", path: "#{github_url}/scripts/mongodb.sh", args: [mongo_enable_remote, mongo_version]
+  # config.vm.provision "shell", path: "#{github_url}/scripts/mongodb.sh", args: [mongo_enable_remote, mongo_version, php_version]
 
   # Provision MariaDB
   # config.vm.provision "shell", path: "#{github_url}/scripts/mariadb.sh", args: [mysql_root_password, mysql_enable_remote]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,9 +2,9 @@
 # vi: set ft=ruby :
 
 # Config Github Settings
-github_username = "Repox"
+github_username = "fideloper"
 github_repo     = "Vaprobash"
-github_branch   = "feature/ubuntu-16.04"
+github_branch   = "1.4.2"
 github_url      = "https://raw.githubusercontent.com/#{github_username}/#{github_repo}/#{github_branch}"
 
 # Because this:https://developer.github.com/changes/2014-12-08-removing-authorizations-token/
@@ -43,7 +43,7 @@ mongo_enable_remote   = "false"  # remote access enabled when true
 
 # Languages and Packages
 php_timezone          = "UTC"    # http://php.net/manual/en/timezones.php
-php_version           = "7.1"    # Options: 5.6 | 7.0 | 7.1
+php_version           = "5.6"    # Options: 5.5 | 5.6 | 7.0 | 7.1
 ruby_version          = "latest" # Choose what ruby version should be installed (will also be the default version)
 ruby_gems             = [        # List any Ruby Gems that you want to install
   #"jekyll",
@@ -91,8 +91,8 @@ elasticsearch_version = "2.3.1" # 5.0.0-alpha1, 2.3.1, 2.2.2, 2.1.2, 1.7.5
 
 Vagrant.configure("2") do |config|
 
-  # Set server to Ubuntu 16.04
-  config.vm.box = "bento/ubuntu-16.04"
+  # Set server to Ubuntu 14.04
+  config.vm.box = "ubuntu/trusty64"
 
   config.vm.define "Vaprobash" do |vapro|
   end

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -2,16 +2,20 @@
 
 echo ">>> Installing Docker"
 
+# Install required packaes (beyond base packages)
+sudo apt-get install -qq apt-transport-https ca-certificates
+
 # Add Key
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 
 # Add Repository
-sudo sh -c "echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
 sudo apt-get update
 
 # Install Docker
 # -qq implies -y --force-yes
-sudo apt-get install -qq lxc-docker
+sudo apt-get install -qq docker-ce
 
 # Make the vagrant user able to interact with docker without sudo
 if [ ! -z "$1" ]; then

--- a/scripts/elasticsearch.sh
+++ b/scripts/elasticsearch.sh
@@ -8,7 +8,7 @@ ELASTICSEARCH_VERSION=$1 # Check https://www.elastic.co/downloads/elasticsearch 
 # Install prerequisite: Java
 # -qq implies -y --force-yes
 sudo apt-get update
-sudo apt-get install -qq openjdk-7-jre-headless
+sudo apt-get install -qq openjdk-9-jre-headless
 
 wget --quiet https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.deb
 sudo dpkg -i elasticsearch-$ELASTICSEARCH_VERSION.deb

--- a/scripts/elasticsearch.sh
+++ b/scripts/elasticsearch.sh
@@ -8,7 +8,7 @@ ELASTICSEARCH_VERSION=$1 # Check https://www.elastic.co/downloads/elasticsearch 
 # Install prerequisite: Java
 # -qq implies -y --force-yes
 sudo apt-get update
-sudo apt-get install -qq openjdk-9-jre-headless
+sudo apt-get install -qq openjdk-7-jre-headless
 
 wget --quiet https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.deb
 sudo dpkg -i elasticsearch-$ELASTICSEARCH_VERSION.deb

--- a/scripts/mariadb.sh
+++ b/scripts/mariadb.sh
@@ -8,10 +8,10 @@ echo ">>> Installing MariaDB"
 MARIADB_VERSION='10.1'
 
 # Import repo key
-sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
+sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
 
 # Add repo for MariaDB
-sudo add-apt-repository "deb [arch=amd64,i386] http://mirrors.accretive-networks.net/mariadb/repo/$MARIADB_VERSION/ubuntu trusty main"
+sudo add-apt-repository "deb [arch=amd64,i386] http://mirrors.accretive-networks.net/mariadb/repo/$MARIADB_VERSION/ubuntu xenial main"
 
 # Update
 sudo apt-get update

--- a/scripts/mariadb.sh
+++ b/scripts/mariadb.sh
@@ -8,10 +8,10 @@ echo ">>> Installing MariaDB"
 MARIADB_VERSION='10.1'
 
 # Import repo key
-sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
+sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
 
 # Add repo for MariaDB
-sudo add-apt-repository "deb [arch=amd64,i386] http://mirrors.accretive-networks.net/mariadb/repo/$MARIADB_VERSION/ubuntu xenial main"
+sudo add-apt-repository "deb [arch=amd64,i386] http://mirrors.accretive-networks.net/mariadb/repo/$MARIADB_VERSION/ubuntu trusty main"
 
 # Update
 sudo apt-get update

--- a/scripts/mysql.sh
+++ b/scripts/mysql.sh
@@ -8,7 +8,10 @@ mysql_package=mysql-server
 
 if [ $2 == "5.6" ]; then
     # Add repo for MySQL 5.6
-	sudo add-apt-repository -y ppa:ondrej/mysql-5.6
+	sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty universe'
+
+    # Remove flag file to avoid dpkg error
+    sudo rm /var/lib/mysql/debian-5.7.flag
 
 	# Update Again
 	sudo apt-get update
@@ -28,12 +31,16 @@ sudo apt-get install -qq $mysql_package
 
 # Make MySQL connectable from outside world without SSH tunnel
 if [ $3 == "true" ]; then
-    # enable remote access
-    # setting the mysql bind-address to allow connections from everywhere
+
     if [ $2 == "5.6" ]; then
-        sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf
+
+cat > /etc/mysql/conf.d/mysqld.cnf << EOF
+[mysqld]
+bind-address = 0.0.0.0
+EOF
+
     else
-        sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
+         sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf
     fi
 
     # adding grant privileges to mysql root user from everywhere

--- a/scripts/pgsql.sh
+++ b/scripts/pgsql.sh
@@ -5,7 +5,7 @@ echo ">>> Installing PostgreSQL"
 [[ -z "$1" ]] && { echo "!!! PostgreSQL root password not set. Check the Vagrant file."; exit 1; }
 
 # Set some variables
-POSTGRE_VERSION=9.4
+POSTGRE_VERSION=9.6
 
 # Add PostgreSQL GPG public key
 # to get latest stable
@@ -14,14 +14,14 @@ wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-
 # Add PostgreSQL Apt repository
 # to get latest stable
 sudo touch /etc/apt/sources.list.d/pgdg.list
-sudo echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+sudo echo "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
 
 # Update Apt repos
 sudo apt-get update
 
 # Install PostgreSQL
 # -qq implies -y --force-yes
-sudo apt-get install -qq postgresql postgresql-contrib
+sudo apt-get install -qq postgresql-$POSTGRE_VERSION postgresql-contrib-$POSTGRE_VERSION
 
 
 # Configure PostgreSQL


### PR DESCRIPTION
This pull request specifically targets the upgrade of Ubuntu from 14.04 to 16.04.

Here are some key topics that this upgrade has impact on, which is important to users for this version:

- Docker has been changes to Docker CE
- MongoDB has been updated to versions 3.2 and 3.4 (2.6 had EOL in 2016, 3.0 is troublesome)
- Updated repository and version (to 9.6) for PostgreSQL
- MySQL versions has been bumped to 5.6 and 5.7. 5.5 is no longer available

To test this branch, please make a checkout of this branch (to reflect the version changes in the Vagrantfile) and change your configuration in the Vagrantfile to the following:

    # Config Github Settings
    github_username = "Repox"
    github_repo     = "Vaprobash"
    github_branch   = "feature/ubuntu-16.04"
    github_url      = "https://raw.githubusercontent.com/#{github_username}/#{github_repo}/#{github_branch}"


I'd appreciate any feedback if you have trouble with the builds.